### PR TITLE
misc: Make it stable compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ description = "Rust bindings for Inochi2D"
 [features]
 default = ["opengl"]
 opengl = []
+nightly = []
 
 [dependencies]
 libc = "0.2"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -6,9 +6,8 @@
 */
 
 mod binding {
-    extern "C" {
-        pub type InCamera;
-    }
+    create_opaque_type!(InCamera);
+
     pub type InCameraPtr = *mut InCamera;
 
     extern "C" {

--- a/src/core.rs
+++ b/src/core.rs
@@ -10,9 +10,7 @@ use crate::puppet::Inochi2DPuppet;
 use std::path::PathBuf;
 mod binding {
     /* Types */
-    extern "C" {
-        pub type InRenderable;
-    }
+    create_opaque_type!(InRenderable);
 
     pub type InTimingFunc = extern fn() -> f64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(extern_types)]
-
+#![cfg_attr(feature = "nightly", feature(extern_types))]
 /*
     Copyright © 2022, Inochi2D Project
     Distributed under the 2-Clause BSD License, see LICENSE file.
@@ -11,6 +10,9 @@
     An attempted idiomatic wrapper for [Inochi2D](https://github.com/Inochi2D/inochi2d).
 
 */
+
+#[macro_use]
+mod macros;
 
 pub mod camera;
 pub mod core;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,14 @@
+macro_rules! create_opaque_type {
+    ($type_name:ident) => {
+        #[cfg(feature = "nightly")]
+        extern "C" {
+            pub type $type_name;
+        }
+
+        #[cfg(not(feature = "nightly"))]
+        #[repr(C)]
+        pub struct $type_name {
+            _private: [u8; 0],
+        }
+    };
+}

--- a/src/puppet.rs
+++ b/src/puppet.rs
@@ -8,9 +8,8 @@
 use std::path::PathBuf;
 
 mod binding {
-    extern "C" {
-        pub type InPuppet;
-    }
+    create_opaque_type!(InPuppet);
+
     pub type InPuppetPtr = *mut InPuppet;
 
     extern "C" {


### PR DESCRIPTION
This PR adds a new feature "nightly" to hides ``extern_types`` requirement behind a ``cfg!``.

When the feature isn't active, a ``repr(C)`` struct is defined with a size of 0 (with one of the old tricks around for that matter)

I took the liberty to hide this boilerplate around a simple macro.

This fix build on stable compiler.