### PR TITLE
misc: Move library dependency to ffi block

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,5 @@ fn main() {
         }
     }
 
-    println!("cargo:rustc-link-lib=inochi2d-c");
     println!("cargo:rustc-link-search=native={}", libdir.display());
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -24,6 +24,7 @@ pub mod types {
     pub type InTimingFunc = extern "C" fn() -> f64;
 }
 
+#[link(name = "inochi2d-c", kind = "dylib")]
 extern "C" {
     /* Core Functionality */
     pub fn inInit(timing: types::InTimingFunc);


### PR DESCRIPTION
That make it more explicit what require what